### PR TITLE
Introduce auto parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ acsiomatic_device_detector:
 
         # If null, it will not assign Twig variable
         variable_name: 'device'
+
+    # If true, DeviceDetector will trigger parser() when necessary
+    auto_parse: true
 ```
 
 ## Usage in controllers
@@ -68,8 +71,6 @@ class MyController
 {
     public function index(DeviceDetector $device)
     {
-        $device->parse();
-
         if ($device->isSmartphone()) {
             // ...
         }
@@ -77,15 +78,13 @@ class MyController
 }
 ```
 
-Note that you need to call `parse()` to ask for device's information.
+Note that you need to call `$device->parse()` before asking for device's information if `auto_parse` configuration is false.
 
 ## Usage in Twig
 
 The `DeviceDetector` service is assigned to the Twig templates as `device` variable.
 
 ```twig
-{% do device.parse %}
-
 {% if device.isSmartphone %}
     {# ... #}
 {% endif %}
@@ -116,7 +115,6 @@ class SmartphoneDeterminer
     {
         $deviceDetector = $this->deviceDetectorFactory->createDeviceDetector();
         $deviceDetector->setUserAgent($userAgent);
-        $deviceDetector->parse();
 
         return $deviceDetector->isSmartphone();
     }

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
+        "friendsofphp/proxy-manager-lts": "^1.0",
         "matomo/device-detector": "^3.9 || ^4.0 || ^5.0",
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,4 +3,20 @@ parameters:
     paths:
         - src
         - tests
+    typeAliases:
+        BundleConfigArray: '''
+            array{
+                cache: array{
+                    pool: string|null
+                },
+                bot: array{
+                    skip_detection: bool,
+                    discard_information: bool
+                },
+                twig: array{
+                    variable_name: string|null
+                },
+                auto_parse: bool
+            }
+'''
     tmpDir: var/phpstan

--- a/src/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/CacheWarmer/ProxyCacheWarmer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Acsiomatic\DeviceDetectorBundle\CacheWarmer;
+
+use Acsiomatic\DeviceDetectorBundle\Factory\DeviceDetectorProxyFactory;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * @internal
+ */
+final class ProxyCacheWarmer implements CacheWarmerInterface
+{
+    /**
+     * @var DeviceDetectorProxyFactory
+     */
+    private $proxyFactory;
+
+    public function __construct(DeviceDetectorProxyFactory $proxyFactory)
+    {
+        $this->proxyFactory = $proxyFactory;
+    }
+
+    public function isOptional(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param string $cacheDir
+     *
+     * @return string[]
+     */
+    public function warmUp($cacheDir)
+    {
+        $proxyDir = $this->proxyFactory->getProxyDir();
+        if (!is_dir($proxyDir)) {
+            if (!mkdir($proxyDir, 0777, true) && !is_dir($proxyDir)) {
+                throw new \RuntimeException(sprintf('Unable to create the DeviceDetector Proxy directory "%s".', $proxyDir));
+            }
+        } elseif (!is_writable($proxyDir)) {
+            throw new \RuntimeException(sprintf('The DeviceDetector Proxy directory "%s" is not writeable for the current system user.', $proxyDir));
+        }
+
+        $this->proxyFactory->createDeviceDetectorProxy();
+
+        $files = [];
+
+        $names = scandir($proxyDir) ?: [];
+        foreach ($names as $name) {
+            $file = $proxyDir.'/'.$name;
+            if (!is_dir($file)) {
+                $files[] = $file;
+            }
+        }
+
+        return $files;
+    }
+}

--- a/src/DependencyInjection/AcsiomaticDeviceDetectorExtension.php
+++ b/src/DependencyInjection/AcsiomaticDeviceDetectorExtension.php
@@ -2,8 +2,10 @@
 
 namespace Acsiomatic\DeviceDetectorBundle\DependencyInjection;
 
+use Acsiomatic\DeviceDetectorBundle\CacheWarmer\ProxyCacheWarmer;
 use Acsiomatic\DeviceDetectorBundle\Contracts\DeviceDetectorFactoryInterface;
 use Acsiomatic\DeviceDetectorBundle\Factory\DeviceDetectorFactory;
+use Acsiomatic\DeviceDetectorBundle\Factory\DeviceDetectorProxyFactory;
 use Acsiomatic\DeviceDetectorBundle\Twig\TwigExtension;
 use DeviceDetector\DeviceDetector;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -23,8 +25,47 @@ final class AcsiomaticDeviceDetectorExtension extends Extension
     public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
+
+        /** @var BundleConfigArray $config */
         $config = $this->processConfiguration($configuration, $configs);
 
+        $this->setupProxy($container, $config);
+        $this->setupFactory($container, $config);
+        $this->setupDeviceDetector($container);
+        $this->setupTwig($container, $config);
+    }
+
+    /**
+     * @param BundleConfigArray $config
+     */
+    private function setupProxy(ContainerBuilder $container, array $config): void
+    {
+        if (!$config['auto_parse']) {
+            return;
+        }
+
+        $container
+            ->register(ProxyCacheWarmer::class, ProxyCacheWarmer::class)
+            ->setPublic(false)
+            ->addTag('kernel.cache_warmer')
+            ->setArguments([
+                new Reference(DeviceDetectorProxyFactory::class),
+                $container->getParameter('kernel.cache_dir'),
+            ]);
+
+        $container
+            ->register(DeviceDetectorProxyFactory::class, DeviceDetectorProxyFactory::class)
+            ->setPublic(false)
+            ->setArguments([
+                $container->getParameter('kernel.cache_dir'),
+            ]);
+    }
+
+    /**
+     * @param BundleConfigArray $config
+     */
+    private function setupFactory(ContainerBuilder $container, array $config): void
+    {
         $container
             ->register(DeviceDetectorFactoryInterface::class, DeviceDetectorFactory::class)
             ->setPublic(false)
@@ -32,9 +73,12 @@ final class AcsiomaticDeviceDetectorExtension extends Extension
                 $config['bot']['skip_detection'],
                 $config['bot']['discard_information'],
                 $config['cache']['pool'] !== null ? new Reference($config['cache']['pool']) : null,
-            ])
-        ;
+                $config['auto_parse'] ? new Reference(DeviceDetectorProxyFactory::class) : null,
+            ]);
+    }
 
+    private function setupDeviceDetector(ContainerBuilder $container): void
+    {
         $container
             ->register(DeviceDetector::class, DeviceDetector::class)
             ->setPublic(false)
@@ -42,19 +86,25 @@ final class AcsiomaticDeviceDetectorExtension extends Extension
             ->setArguments([
                 new Reference(DeviceDetectorFactoryInterface::class),
                 new Reference(RequestStack::class),
-            ])
-        ;
+            ]);
+    }
 
-        if ($config['twig']['variable_name'] !== null && class_exists(Environment::class)) {
-            $container
-                ->register(TwigExtension::class, TwigExtension::class)
-                ->setPublic(false)
-                ->addTag('twig.extension')
-                ->setArguments([
-                    $config['twig']['variable_name'],
-                    new Reference(DeviceDetector::class),
-                ])
-            ;
+    /**
+     * @param BundleConfigArray $config
+     */
+    private function setupTwig(ContainerBuilder $container, array $config): void
+    {
+        if ($config['twig']['variable_name'] === null || !class_exists(Environment::class)) {
+            return;
         }
+
+        $container
+            ->register(TwigExtension::class, TwigExtension::class)
+            ->setPublic(false)
+            ->addTag('twig.extension')
+            ->setArguments([
+                $config['twig']['variable_name'],
+                new Reference(DeviceDetector::class),
+            ]);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -44,8 +44,9 @@ final class Configuration implements ConfigurationInterface
             ->end()
             ->end()
 
-            ->end()
-        ;
+            ->booleanNode('auto_parse')->defaultTrue()->end()
+
+            ->end();
 
         return $builder;
     }

--- a/src/Factory/DeviceDetectorFactory.php
+++ b/src/Factory/DeviceDetectorFactory.php
@@ -28,19 +28,28 @@ final class DeviceDetectorFactory implements DeviceDetectorFactoryInterface
      */
     private $cache;
 
+    /**
+     * @var DeviceDetectorProxyFactory|null
+     */
+    private $proxyFactory;
+
     public function __construct(
         bool $skipBotDetection,
         bool $discardBotInformation,
-        CacheItemPoolInterface $cache = null
+        ?CacheItemPoolInterface $cache,
+        ?DeviceDetectorProxyFactory $proxyFactory
     ) {
         $this->skipBotDetection = $skipBotDetection;
         $this->discardBotInformation = $discardBotInformation;
         $this->cache = $cache;
+        $this->proxyFactory = $proxyFactory;
     }
 
     public function createDeviceDetector(): DeviceDetector
     {
-        $detector = new DeviceDetector();
+        $detector = $this->proxyFactory !== null
+            ? $this->proxyFactory->createDeviceDetectorProxy()
+            : new DeviceDetector();
 
         $detector->skipBotDetection($this->skipBotDetection);
         $detector->discardBotInformation($this->discardBotInformation);

--- a/src/Factory/DeviceDetectorProxyFactory.php
+++ b/src/Factory/DeviceDetectorProxyFactory.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Acsiomatic\DeviceDetectorBundle\Factory;
+
+use DeviceDetector\DeviceDetector;
+use ProxyManager\Configuration;
+use ProxyManager\Factory\AccessInterceptorValueHolderFactory;
+use ProxyManager\FileLocator\FileLocator;
+use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
+
+/**
+ * @internal
+ */
+final class DeviceDetectorProxyFactory
+{
+    /**
+     * @var string
+     */
+    private const NAMESPACE = 'AcsiomaticDeviceDetectorBundle';
+
+    /**
+     * @var string
+     */
+    private $proxyDir;
+
+    public function __construct(string $cacheDir)
+    {
+        $this->proxyDir = $cacheDir.'/'.self::NAMESPACE;
+    }
+
+    public function getProxyDir(): string
+    {
+        return $this->proxyDir;
+    }
+
+    public function createDeviceDetectorProxy(): DeviceDetector
+    {
+        $parseCaller = static function (
+            DeviceDetector $proxy,
+            DeviceDetector $real
+        ): void {
+            if (!$real->isParsed()) {
+                $real->parse();
+            }
+        };
+
+        $magicParseCaller = static function (
+            DeviceDetector $proxy,
+            DeviceDetector $real,
+            string $method,
+            array $arguments
+        ): void {
+            if (!$real->isParsed() && 0 === stripos($arguments['methodName'] ?? '', 'is')) {
+                $real->parse();
+            }
+        };
+
+        $configuration = $this->createConfiguration();
+        $factory = new AccessInterceptorValueHolderFactory($configuration);
+
+        return $factory->createProxy(new DeviceDetector(), [
+            '__call' => $magicParseCaller,
+            'getBot' => $parseCaller,
+            'getBrand' => $parseCaller,
+            'getBrandName' => $parseCaller,
+            'getClient' => $parseCaller,
+            'getDevice' => $parseCaller,
+            'getDeviceName' => $parseCaller,
+            'getModel' => $parseCaller,
+            'getOs' => $parseCaller,
+            'isBot' => $parseCaller,
+            'isBrowser' => $parseCaller,
+            'isDesktop' => $parseCaller,
+            'isMobile' => $parseCaller,
+        ]);
+    }
+
+    private function createConfiguration(): Configuration
+    {
+        $config = new Configuration();
+        $config->setProxiesNamespace(self::NAMESPACE);
+        $config->setGeneratorStrategy(new FileWriterGeneratorStrategy(new FileLocator($this->proxyDir)));
+        $config->setProxiesTargetDir($this->proxyDir);
+
+        $config->getProxyAutoloader();
+
+        return $config;
+    }
+}

--- a/tests/AutoParseTest.php
+++ b/tests/AutoParseTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Acsiomatic\DeviceDetectorBundle\Tests;
+
+use Acsiomatic\DeviceDetectorBundle\AcsiomaticDeviceDetectorBundle;
+use Acsiomatic\DeviceDetectorBundle\Contracts\DeviceDetectorFactoryInterface;
+use Acsiomatic\DeviceDetectorBundle\Tests\Util\Compiler\CompilerPassFactory;
+use Acsiomatic\DeviceDetectorBundle\Tests\Util\HttpKernel\Kernel;
+use DeviceDetector\DeviceDetector;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+final class AutoParseTest extends TestCase
+{
+    /**
+     * @var Kernel
+     */
+    private static $kernelDefault;
+
+    /**
+     * @var Kernel
+     */
+    private static $kernelDisabled;
+
+    /**
+     * @beforeClass
+     */
+    public static function setUpKernel(): void
+    {
+        $kernelDefault = new Kernel('test', true);
+
+        $kernelDefault->appendBundle(new FrameworkBundle());
+        $kernelDefault->appendBundle(new AcsiomaticDeviceDetectorBundle());
+        $kernelDefault->appendExtensionConfiguration('framework', ['test' => true, 'secret' => '53CR37']);
+        $kernelDefault->appendCompilerPass(CompilerPassFactory::createPublicAlias('device_detector.public', DeviceDetector::class));
+        $kernelDefault->appendCompilerPass(CompilerPassFactory::createPublicAlias('device_detector_factory.public', DeviceDetectorFactoryInterface::class));
+
+        $kernelDefault->boot();
+
+        self::$kernelDefault = $kernelDefault;
+
+        $kernelDisabled = new Kernel('test', true);
+
+        $kernelDisabled->appendBundle(new FrameworkBundle());
+        $kernelDisabled->appendBundle(new AcsiomaticDeviceDetectorBundle());
+        $kernelDisabled->appendExtensionConfiguration('framework', ['test' => true, 'secret' => '53CR37']);
+        $kernelDisabled->appendExtensionConfiguration('acsiomatic_device_detector', ['auto_parse' => false]);
+        $kernelDisabled->appendCompilerPass(CompilerPassFactory::createPublicAlias('device_detector.public', DeviceDetector::class));
+        $kernelDisabled->appendCompilerPass(CompilerPassFactory::createPublicAlias('device_detector_factory.public', DeviceDetectorFactoryInterface::class));
+
+        $kernelDisabled->boot();
+
+        self::$kernelDisabled = $kernelDisabled;
+    }
+
+    public function testParserIsNotCalledByDefault(): void
+    {
+        /** @var DeviceDetector $deviceDetector */
+        $deviceDetector = self::$kernelDefault->getContainer()->get('device_detector.public');
+
+        static::assertFalse($deviceDetector->isParsed());
+    }
+
+    public function testParserIsNotCalledByDefaultInInstanceFromFactory(): void
+    {
+        /** @var DeviceDetectorFactoryInterface $factory */
+        $factory = self::$kernelDefault->getContainer()->get('device_detector_factory.public');
+        $deviceDetector = $factory->createDeviceDetector();
+
+        static::assertFalse($deviceDetector->isParsed());
+    }
+
+    /**
+     * @dataProvider nonTriggersMethods
+     *
+     * @param mixed ...$arguments
+     */
+    public function testParserIsNotTriggeredFor(string $method, ...$arguments): void
+    {
+        /** @var DeviceDetector $deviceDetector */
+        $deviceDetector = self::$kernelDefault->getContainer()->get('device_detector.public');
+        $deviceDetector->setUserAgent('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0');
+
+        static::assertFalse($deviceDetector->isParsed());
+
+        try {
+            $deviceDetector->$method(...$arguments);
+        } catch (\BadMethodCallException $badMethodCallException) {
+            static::markTestSkipped(sprintf('Method "%s" not available in this version', $method));
+        }
+
+        static::assertFalse($deviceDetector->isParsed());
+    }
+
+    /**
+     * @return iterable<string[]>
+     */
+    public function nonTriggersMethods(): iterable
+    {
+        yield 'discardBotInformation()' => ['discardBotInformation'];
+        yield 'getUserAgent()' => ['getUserAgent'];
+        yield 'setUserAgent()' => ['setUserAgent', 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0'];
+        yield 'skipBotDetection()' => ['skipBotDetection'];
+    }
+
+    /**
+     * @dataProvider triggersMethods
+     * @dataProvider triggersTypeMagicMethods
+     * @dataProvider triggersClientMagicTypeMethods
+     */
+    public function testParserIsTriggeredIfAutoParserIsEnabled(string $method): void
+    {
+        /** @var DeviceDetectorFactoryInterface $factory */
+        $factory = self::$kernelDefault->getContainer()->get('device_detector_factory.public');
+
+        $deviceDetector = $factory->createDeviceDetector();
+        $deviceDetector->setUserAgent('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0');
+
+        static::assertFalse($deviceDetector->isParsed());
+
+        try {
+            $deviceDetector->$method();
+        } catch (\BadMethodCallException $badMethodCallException) {
+            static::markTestSkipped(sprintf('Method "%s" not available in this version', $method));
+        }
+
+        static::assertTrue($deviceDetector->isParsed());
+    }
+
+    /**
+     * @dataProvider triggersMethods
+     * @dataProvider triggersTypeMagicMethods
+     * @dataProvider triggersClientMagicTypeMethods
+     *
+     * @param mixed ...$arguments
+     */
+    public function testParserIsNotCalledIfAutoParseIsDisabled(string $method, ...$arguments): void
+    {
+        /** @var DeviceDetectorFactoryInterface $factory */
+        $factory = self::$kernelDisabled->getContainer()->get('device_detector_factory.public');
+        $deviceDetector = $factory->createDeviceDetector();
+
+        static::assertFalse($deviceDetector->isParsed());
+
+        try {
+            $deviceDetector->$method(...$arguments);
+        } catch (\BadMethodCallException $badMethodCallException) {
+            static::markTestSkipped(sprintf('Method "%s" not available in this version', $method));
+        }
+
+        static::assertFalse($deviceDetector->isParsed());
+    }
+
+    /**
+     * @return iterable<string[]>
+     */
+    public function triggersMethods(): iterable
+    {
+        yield 'getBot()' => ['getBot'];
+        yield 'getBrand()' => ['getBrand'];
+        yield 'getBrandName()' => ['getBrandName'];
+        yield 'getClient()' => ['getClient'];
+        yield 'getDevice()' => ['getDevice'];
+        yield 'getDeviceName()' => ['getDeviceName'];
+        yield 'getModel()' => ['getModel'];
+        yield 'getOs()' => ['getOs'];
+        yield 'isBot()' => ['isBot'];
+        yield 'isDesktop()' => ['isDesktop'];
+        yield 'isMobile()' => ['isMobile'];
+    }
+
+    /**
+     * @return iterable<string[]>
+     */
+    public function triggersTypeMagicMethods(): iterable
+    {
+        yield 'isCamera()' => ['isCamera'];
+        yield 'isCarBrowser()' => ['isCarBrowser'];
+        yield 'isConsole()' => ['isConsole'];
+        yield 'isFeaturePhone()' => ['isFeaturePhone'];
+        yield 'isPeripheral()' => ['isPeripheral'];
+        yield 'isPhablet()' => ['isPhablet'];
+        yield 'isPortableMediaPlayer()' => ['isPortableMediaPlayer'];
+        yield 'isSmartDisplay()' => ['isSmartDisplay'];
+        yield 'isSmartSpeaker()' => ['isSmartSpeaker'];
+        yield 'isSmartphone()' => ['isSmartphone'];
+        yield 'isTV()' => ['isTV'];
+        yield 'isTablet()' => ['isTablet'];
+        yield 'isWearable()' => ['isWearable'];
+    }
+
+    /**
+     * @return iterable<string[]>
+     */
+    public function triggersClientMagicTypeMethods(): iterable
+    {
+        yield 'isBrowser()' => ['isBrowser'];
+        yield 'isFeedReader()' => ['isFeedReader'];
+        yield 'isLibrary()' => ['isLibrary'];
+        yield 'isMediaPlayer()' => ['isMediaPlayer'];
+        yield 'isMobileApp()' => ['isMobileApp'];
+        yield 'isPIM()' => ['isPIM'];
+    }
+}

--- a/tests/ServiceAvailabilityTest.php
+++ b/tests/ServiceAvailabilityTest.php
@@ -22,7 +22,7 @@ final class ServiceAvailabilityTest extends TestCase
         $kernel->appendExtensionConfiguration('framework', ['test' => true, 'secret' => '53CR37']);
         $kernel->appendCompilerPass(
             new CallbackContainerPass(
-                static function (ContainerBuilder $containerBuilder) {
+                static function (ContainerBuilder $containerBuilder): void {
                     self::assertTrue($containerBuilder->hasDefinition(DeviceDetector::class));
                     self::assertFalse($containerBuilder->getDefinition(DeviceDetector::class)->isPublic());
                 }

--- a/tests/Util/Compiler/CompilerPassFactory.php
+++ b/tests/Util/Compiler/CompilerPassFactory.php
@@ -13,7 +13,7 @@ abstract class CompilerPassFactory
     public static function createPublicAlias(string $alias, string $id): CompilerPassInterface
     {
         return new CallbackContainerPass(
-            static function (ContainerBuilder $containerBuilder) use ($alias, $id) {
+            static function (ContainerBuilder $containerBuilder) use ($alias, $id): void {
                 $containerBuilder
                     ->setAlias($alias, $id)
                     ->setPublic(true)
@@ -25,7 +25,7 @@ abstract class CompilerPassFactory
     public static function createTraceableCache(string $id): CompilerPassInterface
     {
         return new CallbackContainerPass(
-            static function (ContainerBuilder $containerBuilder) use ($id) {
+            static function (ContainerBuilder $containerBuilder) use ($id): void {
                 if (!$containerBuilder->hasDefinition($id)) {
                     $containerBuilder->register($id, NullAdapter::class);
                 }

--- a/tests/Util/HttpKernel/Kernel.php
+++ b/tests/Util/HttpKernel/Kernel.php
@@ -22,7 +22,7 @@ final class Kernel extends BaseKernel
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        $loader->load(function (ContainerBuilder $container) {
+        $loader->load(function (ContainerBuilder $container): void {
             foreach ($this->appendedExtensionConfigurations as $extension => $config) {
                 $container->loadFromExtension($extension, $config);
             }


### PR DESCRIPTION
closes #7

- [x] Call `DeviceDetector::parser()` whenever it's required
- [x] Introduce `auto_parser` configuration to allow disable this feature
- [x] Warmup proxy generator for production
- [x] Documentation
