### PR TITLE
Add DeviceDetect proxy to autoload.

### DIFF
--- a/src/Factory/DeviceDetectorProxyFactory.php
+++ b/src/Factory/DeviceDetectorProxyFactory.php
@@ -72,7 +72,9 @@ final class DeviceDetectorProxyFactory
         $config->setGeneratorStrategy(new FileWriterGeneratorStrategy(new FileLocator($this->proxyDir)));
         $config->setProxiesTargetDir($this->proxyDir);
 
-        $config->getProxyAutoloader();
+        /** @var callable $loader */
+        $loader = $config->getProxyAutoloader();
+        spl_autoload_register($loader);
 
         return $config;
     }


### PR DESCRIPTION
Add proxy class to autoloading to fix problem when already exists file with the same hash overrwited on every request