### PR TITLE
Declare argument  of ProxyCacheWarmer::warmUp nullable

### DIFF
--- a/src/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/CacheWarmer/ProxyCacheWarmer.php
@@ -20,7 +20,7 @@ final class ProxyCacheWarmer implements CacheWarmerInterface
         return false;
     }
 
-    public function warmUp(string $cacheDir, string $buildDir = null): array
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
         $proxyDir = $this->proxyFactory->getProxyDir();
         if (!is_dir($proxyDir)) {


### PR DESCRIPTION
# Declare argument  of ProxyCacheWarmer::warmUp nullable

So that PHP 8 doesn't trigger a deprecation warning :

> Acsiomatic\DeviceDetectorBundle\CacheWarmer\ProxyCacheWarmer::warmUp(): Implicitly marking parameter $buildDir as nullable is deprecated, the explicit nullable type must be used instead

